### PR TITLE
Sam live only firestore seeder

### DIFF
--- a/src/main/java/com/laughingalpaca/bikeviewapp/Controller/MainController.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/Controller/MainController.java
@@ -68,6 +68,7 @@ public class MainController implements Initializable {
     public void initialize(URL url, ResourceBundle resourceBundle) {
         InitializeEventHandlers();
         InitializeChoiceBoxes();
+        InitializeMapView(new ArrayList<>());
 
     }
 

--- a/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
@@ -49,7 +49,7 @@ public class DataHandler {
         return INSTANCE;
     }
 
-    private DataHandler() {
+    public DataHandler() {
         refreshConnectionStatus();
     }
 
@@ -172,24 +172,25 @@ public class DataHandler {
         return firestore == null ? "Offline" : "N/A";
     }
 
-    //TODO: WAITING FOR Station to be implemented as expect.
-//    public synchronized String getLastUpdatedDisplay() {
-//        Optional<Instant> metadataTime = getMetadataLastUpdated();
-//        if (metadataTime.isPresent()) {
-//            return DISPLAY_DATE_FORMAT.format(metadataTime.get());
-//        }
-//        Optional<Instant> stationTime = cachedStations.stream()
-//                .map(Station::getLast_updated)
-//                .filter(Objects::nonNull)
-//                .max(Comparator.naturalOrder().reversed()); // TODO: CHECK THIS WORKS PROPERLY
-//        if (stationTime.isPresent()) {
-//            return DISPLAY_DATE_FORMAT.format(stationTime.get());
-//        }
-//        if (lastSuccessfulRefresh != null) {
-//            return DISPLAY_DATE_FORMAT.format(lastSuccessfulRefresh);
-//        }
-//        return "Unavailable";
-//    }
+
+    public synchronized String getLastUpdatedDisplay() {
+        Optional<Instant> metadataTime = getMetadataLastUpdated();
+        if (metadataTime.isPresent()) {
+            return DISPLAY_DATE_FORMAT.format(metadataTime.get());
+        }
+        Optional<Instant> stationTime = cachedStations.stream()
+                .map(Station::getLast_updated)
+                .filter(Objects::nonNull)
+                .max(Comparator.naturalOrder());
+        if (stationTime.isPresent()) {
+            return DISPLAY_DATE_FORMAT.format(stationTime.get());
+        }
+        if (lastSuccessfulRefresh != null) {
+            return DISPLAY_DATE_FORMAT.format(lastSuccessfulRefresh);
+        }
+        return "Unavailable";
+    }
+
     public synchronized String getStatusMessage() {
         if (usingLiveFallback) {
             return "Using live Citi Bike feed because Firestore is unavailable.";
@@ -211,13 +212,14 @@ public class DataHandler {
         return firestore;
     }
 
-    //TODO: WAITING FOR GeoBoundary to be implemented as expect.
-//    public synchronized Optional<GeoBoundary> getZipBoundary(String zipCode) {
-//        return geoBoundaryService.getZipBoundary(zipCode);
-//    }
-//    public synchronized boolean isStationInsideBoundary(Station station, GeoBoundary boundary) {
-//        return geoBoundaryService.isStationInsideZip(station, boundary);
-//    }
+    public synchronized Optional<GeoBoundary> getZipBoundary(String zipCode) {
+        return geoBoundaryService.getZipBoundary(zipCode);
+    }
+
+    public synchronized boolean isStationInsideBoundary(Station station, GeoBoundary boundary) {
+        return geoBoundaryService.isStationInsideZip(station, boundary);
+    }
+
     private Firestore initializeFirestore() {
         if (!Files.exists(SERVICE_ACCOUNT_PATH)) {
             lastError = "Missing Firebase key at " + SERVICE_ACCOUNT_PATH;
@@ -383,20 +385,21 @@ public class DataHandler {
     }
 
     //TODO: WAITING FOR gbfsSyncService to be implemented as expect.
-//    private List<Station> loadStationsFromFallback() {
-//        try {
-//            List<Station> liveStations = gbfsSyncService.fetchLiveStations();
-//            usingLiveFallback = true;
-//            cacheStations(liveStations);
-//            lastSuccessfulRefresh = Instant.now();
-//            return new ArrayList<>(cachedStations);
-//        } catch (IOException | InterruptedException exception) {
-//            if (exception instanceof InterruptedException) {
-//                Thread.currentThread().interrupt();
-//            }
-//            return new ArrayList<>(cachedStations);
-//        }
-//    }
+    private List<Station> loadStationsFromFallback() {
+        try {
+            List<Station> liveStations = gbfsSyncService.fetchLiveStations();
+            usingLiveFallback = true;
+            cacheStations(liveStations);
+            lastSuccessfulRefresh = Instant.now();
+            return new ArrayList<>(cachedStations);
+        } catch (IOException | InterruptedException exception) {
+            if (exception instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return new ArrayList<>(cachedStations);
+        }
+    }
+
     private void cacheStations(List<Station> stations) {
         cachedStations.clear();
         cachedStations.addAll(stations);
@@ -417,4 +420,4 @@ public class DataHandler {
         return prefix + " " + message;
     }
 }
-}
+

--- a/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
@@ -1,6 +1,420 @@
 package com.laughingalpaca.bikeviewapp;
 
+import com.gluonhq.maps.MapPoint;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.cloud.FirestoreClient;
+import com.laughingalpaca.bikeviewapp.Model.Ride;
+import com.laughingalpaca.bikeviewapp.Model.RideableType;
+import com.laughingalpaca.bikeviewapp.Model.Station;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
 public class DataHandler {
-    //TODO: Handle all data entry here, so here we should be connecting to the database,
-    // updating our data to the latest version, retrieving zipcodes, boroughs, stations.
+    private static final Path SERVICE_ACCOUNT_PATH = Path.of("config", "firebase-service-account.json");
+    private static final DateTimeFormatter DISPLAY_DATE_FORMAT =
+            DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a").withZone(ZoneId.systemDefault());
+    private static final DataHandler INSTANCE = new DataHandler();
+    private final List<Station> cachedStations = new ArrayList<>();
+    private final GbfsSyncService gbfsSyncService = new GbfsSyncService();
+    private final GeoBoundaryService geoBoundaryService = new GeoBoundaryService();
+    private Firestore firestore;
+    private String projectId = "Unavailable";
+    private String lastError = "Not connected";
+    private Instant lastSuccessfulRefresh;
+    private boolean usingLiveFallback;
+
+    public static DataHandler getInstance() {
+        return INSTANCE;
+    }
+
+    private DataHandler() {
+        refreshConnectionStatus();
+    }
+
+    public synchronized boolean refreshConnectionStatus() {
+        firestore = initializeFirestore();
+        if (firestore == null) {
+            return false;
+        }
+        try {
+            firestore.collection("app_metadata").document("status").get().get();
+            lastError = "";
+            lastSuccessfulRefresh = Instant.now();
+            return true;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            lastError = "Firestore connection check interrupted.";
+            return false;
+        } catch (ExecutionException | RuntimeException exception) {
+            lastError = buildReadableError("Firestore connection failed.", exception);
+            return false;
+        }
+    }
+
+    public synchronized List<Station> getAllStations() {
+        if (firestore == null && !refreshConnectionStatus()) {
+            return loadStationsFromFallback();
+        }
+        try {
+            QuerySnapshot querySnapshot = firestore.collection("stations").get().get();
+            List<Station> stations = querySnapshot.getDocuments().stream()
+                    .map(this::mapStation)
+                    .filter(Objects::nonNull)
+                    .sorted(Comparator.comparing(Station::getStation_name, String.CASE_INSENSITIVE_ORDER))
+                    .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+            geoBoundaryService.enrichStationsWithBoroughs(stations);
+            if (stations.isEmpty()) {
+                return loadStationsFromFallback();
+            }
+            usingLiveFallback = false;
+            cacheStations(stations);
+            lastSuccessfulRefresh = Instant.now();
+            lastError = "";
+            return new ArrayList<>(cachedStations);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            lastError = "Station load interrupted.";
+        } catch (ExecutionException | RuntimeException exception) {
+            lastError = buildReadableError("Unable to load stations from Firestore.", exception);
+        }
+        return loadStationsFromFallback();
+    }
+
+    public synchronized List<String> getAllBoroughs() {
+        Set<String> boroughs = new LinkedHashSet<>();
+        for (Station station : getAllStations()) {
+            if (station.getBorough() != null && !station.getBorough().isBlank()) {
+                boroughs.add(station.getBorough());
+            }
+        }
+        return new ArrayList<>(boroughs);
+    }
+
+    public synchronized List<String> getAllStationNames() {
+        return getAllStations().stream()
+                .map(Station::getStation_name)
+                .filter(name -> name != null && !name.isBlank())
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .toList();
+    }
+
+    public synchronized List<Ride> getRidesForStation(String stationId) {
+        if (stationId == null || stationId.isBlank()) {
+            return List.of();
+        }
+        if (firestore == null && !refreshConnectionStatus()) {
+            return List.of();
+        }
+        try {
+            QuerySnapshot querySnapshot = firestore.collection("rides").get().get();
+            List<Ride> rides = new ArrayList<>();
+            for (QueryDocumentSnapshot document : querySnapshot.getDocuments()) {
+                Ride ride = mapRide(document);
+                if (ride == null) {
+                    continue;
+                }
+                boolean matchesStart = ride.getStart_station() != null
+                        && stationId.equalsIgnoreCase(ride.getStart_station().getStation_id());
+                boolean matchesEnd = ride.getEnd_station() != null
+                        && stationId.equalsIgnoreCase(ride.getEnd_station().getStation_id());
+                if (matchesStart || matchesEnd) {
+                    rides.add(ride);
+                }
+            }
+            lastError = "";
+            return rides;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            lastError = "Ride lookup interrupted.";
+        } catch (ExecutionException | RuntimeException exception) {
+            lastError = buildReadableError("Unable to load rides from Firestore.", exception);
+        }
+        return List.of();
+    }
+
+    public synchronized String getProjectDisplayName() {
+        return projectId;
+    }
+
+    public synchronized String getDatabaseDisplayName() {
+        if (usingLiveFallback) {
+            return "Live Citi Bike Feed";
+        }
+        return firestore == null ? "Unavailable" : "Cloud Firestore";
+    }
+
+    public synchronized String getDatabaseHostDisplay() {
+        if (usingLiveFallback) {
+            return "gbfs.lyft.com";
+        }
+        return firestore == null ? "Offline" : "N/A";
+    }
+
+    //TODO: WAITING FOR Station to be implemented as expect.
+//    public synchronized String getLastUpdatedDisplay() {
+//        Optional<Instant> metadataTime = getMetadataLastUpdated();
+//        if (metadataTime.isPresent()) {
+//            return DISPLAY_DATE_FORMAT.format(metadataTime.get());
+//        }
+//        Optional<Instant> stationTime = cachedStations.stream()
+//                .map(Station::getLast_updated)
+//                .filter(Objects::nonNull)
+//                .max(Comparator.naturalOrder().reversed()); // TODO: CHECK THIS WORKS PROPERLY
+//        if (stationTime.isPresent()) {
+//            return DISPLAY_DATE_FORMAT.format(stationTime.get());
+//        }
+//        if (lastSuccessfulRefresh != null) {
+//            return DISPLAY_DATE_FORMAT.format(lastSuccessfulRefresh);
+//        }
+//        return "Unavailable";
+//    }
+    public synchronized String getStatusMessage() {
+        if (usingLiveFallback) {
+            return "Using live Citi Bike feed because Firestore is unavailable.";
+        }
+        if (firestore != null && (lastError == null || lastError.isBlank())) {
+            return "Connected to Firestore.";
+        }
+        return lastError == null || lastError.isBlank() ? "Firestore connection unavailable." : lastError;
+    }
+
+    public synchronized boolean isConnected() {
+        return firestore != null && (lastError == null || lastError.isBlank());
+    }
+
+    public synchronized Firestore getFirestore() {
+        if (firestore == null) {
+            refreshConnectionStatus();
+        }
+        return firestore;
+    }
+
+    //TODO: WAITING FOR GeoBoundary to be implemented as expect.
+//    public synchronized Optional<GeoBoundary> getZipBoundary(String zipCode) {
+//        return geoBoundaryService.getZipBoundary(zipCode);
+//    }
+//    public synchronized boolean isStationInsideBoundary(Station station, GeoBoundary boundary) {
+//        return geoBoundaryService.isStationInsideZip(station, boundary);
+//    }
+    private Firestore initializeFirestore() {
+        if (!Files.exists(SERVICE_ACCOUNT_PATH)) {
+            lastError = "Missing Firebase key at " + SERVICE_ACCOUNT_PATH;
+            return null;
+        }
+        try (FileInputStream inputStream = new FileInputStream(SERVICE_ACCOUNT_PATH.toFile())) {
+            ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(inputStream);
+            projectId = credentials.getProjectId() == null || credentials.getProjectId().isBlank()
+                    ? projectId
+                    : credentials.getProjectId();
+            FirebaseApp firebaseApp;
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(credentials)
+                        .setProjectId(projectId)
+                        .build();
+                firebaseApp = FirebaseApp.initializeApp(options);
+            } else {
+                firebaseApp = FirebaseApp.getInstance();
+            }
+            return FirestoreClient.getFirestore(firebaseApp);
+        } catch (IOException | RuntimeException exception) {
+            lastError = buildReadableError("Unable to initialize Firebase.", exception);
+            return null;
+        }
+    }
+
+    private Optional<Instant> getMetadataLastUpdated() {
+        if (firestore == null || usingLiveFallback) {
+            return Optional.empty();
+        }
+        try {
+            DocumentSnapshot snapshot = firestore.collection("app_metadata").document("status").get().get();
+            Instant instant = extractInstant(snapshot, "lastUpdated")
+                    .or(() -> extractInstant(snapshot, "last_updated"))
+                    .orElse(null);
+            return Optional.ofNullable(instant);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return Optional.empty();
+        } catch (ExecutionException | RuntimeException exception) {
+            return Optional.empty();
+        }
+    }
+
+    private Station mapStation(DocumentSnapshot document) {
+        String stationId = readFirstString(document, "stationId", "station_id", "id");
+        String stationName = readFirstString(document, "stationName", "station_name", "name");
+        Double latitude = readFirstDouble(document, "latitude", "lat");
+        Double longitude = readFirstDouble(document, "longitude", "lng", "lon");
+        if (stationId == null || stationName == null || latitude == null || longitude == null) {
+            return null;
+        }
+        Integer bikeCount = readFirstInteger(document, "estimatedBikeCount", "estimated_bike_count", "bikeCount");
+        Instant lastUpdated = extractInstant(document, "lastUpdated")
+                .or(() -> extractInstant(document, "last_updated"))
+                .orElse(null);
+        return new Station(
+                stationId,
+                stationName,
+                new MapPoint(latitude, longitude),
+                bikeCount == null ? 0 : bikeCount,
+                defaultString(readFirstString(document, "borough")),
+                defaultString(readFirstString(document, "zipCode", "zip_code", "zipcode")),
+                lastUpdated
+        );
+    }
+
+    private Ride mapRide(DocumentSnapshot document) {
+        String rideId = readFirstString(document, "rideId", "ride_id");
+        String rideTypeValue = readFirstString(document, "rideableType", "rideable_type");
+        RideableType rideableType = parseRideableType(rideTypeValue);
+        Station startStation = buildRideStation(document, "startStationId", "start_station_id",
+                "startStationName", "start_station_name");
+        Station endStation = buildRideStation(document, "endStationId", "end_station_id",
+                "endStationName", "end_station_name");
+        Instant startedAt = extractInstant(document, "startedAt")
+                .or(() -> extractInstant(document, "started_at"))
+                .orElse(null);
+        Instant endedAt = extractInstant(document, "endedAt")
+                .or(() -> extractInstant(document, "ended_at"))
+                .orElse(null);
+        if (rideId == null || rideableType == null) {
+            return null;
+        }
+        return new Ride(rideId, rideableType, startStation, endStation, startedAt, endedAt);
+    }
+
+    private Station buildRideStation(DocumentSnapshot document, String idKey, String legacyIdKey,
+                                     String nameKey, String legacyNameKey) {
+        String stationId = readFirstString(document, idKey, legacyIdKey);
+        String stationName = readFirstString(document, nameKey, legacyNameKey);
+        if (stationId == null && stationName == null) {
+            return null;
+        }
+        return new Station(defaultString(stationId), defaultString(stationName), new MapPoint(0, 0), 0);
+    }
+
+    private RideableType parseRideableType(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim().toLowerCase(Locale.US);
+        if ("electric_bike".equals(normalized) || "electric-bike".equals(normalized) || "electric".equals(normalized)) {
+            return RideableType.electric_bike;
+        }
+        if ("classic_bike".equals(normalized) || "classic-bike".equals(normalized) || "classic".equals(normalized)) {
+            return RideableType.classic_bike;
+        }
+        return null;
+    }
+
+    private String readFirstString(DocumentSnapshot document, String... keys) {
+        for (String key : keys) {
+            Object value = document.get(key);
+            if (value instanceof String stringValue && !stringValue.isBlank()) {
+                return stringValue;
+            }
+        }
+        return null;
+    }
+
+    private Double readFirstDouble(DocumentSnapshot document, String... keys) {
+        for (String key : keys) {
+            Object value = document.get(key);
+            if (value instanceof Number number) {
+                return number.doubleValue();
+            }
+        }
+        return null;
+    }
+
+    private Integer readFirstInteger(DocumentSnapshot document, String... keys) {
+        for (String key : keys) {
+            Object value = document.get(key);
+            if (value instanceof Number number) {
+                return number.intValue();
+            }
+        }
+        return null;
+    }
+
+    private Optional<Instant> extractInstant(DocumentSnapshot document, String key) {
+        Object value = document.get(key);
+        if (value instanceof Timestamp timestamp) {
+            return Optional.of(timestamp.toDate().toInstant());
+        }
+        if (value instanceof java.util.Date date) {
+            return Optional.of(date.toInstant());
+        }
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            try {
+                return Optional.of(Instant.parse(stringValue));
+            } catch (RuntimeException ignored) {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String defaultString(String value) {
+        return value == null ? "" : value;
+    }
+
+    //TODO: WAITING FOR gbfsSyncService to be implemented as expect.
+//    private List<Station> loadStationsFromFallback() {
+//        try {
+//            List<Station> liveStations = gbfsSyncService.fetchLiveStations();
+//            usingLiveFallback = true;
+//            cacheStations(liveStations);
+//            lastSuccessfulRefresh = Instant.now();
+//            return new ArrayList<>(cachedStations);
+//        } catch (IOException | InterruptedException exception) {
+//            if (exception instanceof InterruptedException) {
+//                Thread.currentThread().interrupt();
+//            }
+//            return new ArrayList<>(cachedStations);
+//        }
+//    }
+    private void cacheStations(List<Station> stations) {
+        cachedStations.clear();
+        cachedStations.addAll(stations);
+    }
+
+    private String buildReadableError(String prefix, Exception exception) {
+        Throwable rootCause = exception;
+        while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+        }
+        String message = rootCause.getMessage();
+        if (message == null || message.isBlank()) {
+            message = exception.getMessage();
+        }
+        if (message == null || message.isBlank()) {
+            return prefix;
+        }
+        return prefix + " " + message;
+    }
+}
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
@@ -172,24 +172,24 @@ public class DataHandler {
         return firestore == null ? "Offline" : "N/A";
     }
 
-
-    public synchronized String getLastUpdatedDisplay() {
-        Optional<Instant> metadataTime = getMetadataLastUpdated();
-        if (metadataTime.isPresent()) {
-            return DISPLAY_DATE_FORMAT.format(metadataTime.get());
-        }
-        Optional<Instant> stationTime = cachedStations.stream()
-                .map(Station::getLast_updated)
-                .filter(Objects::nonNull)
-                .max(Comparator.naturalOrder());
-        if (stationTime.isPresent()) {
-            return DISPLAY_DATE_FORMAT.format(stationTime.get());
-        }
-        if (lastSuccessfulRefresh != null) {
-            return DISPLAY_DATE_FORMAT.format(lastSuccessfulRefresh);
-        }
-        return "Unavailable";
-    }
+    //TODO: RETURN TO THIS, CURRENTLY NOT WORKING
+//    public synchronized String getLastUpdatedDisplay() {
+//        Optional<Instant> metadataTime = getMetadataLastUpdated();
+//        if (metadataTime.isPresent()) {
+//            return DISPLAY_DATE_FORMAT.format(metadataTime.get());
+//        }
+//        Optional<Instant> stationTime = cachedStations.stream()
+//                .map(Station::getLast_updated)
+//                .filter(Objects::nonNull)
+//                .max(Comparator.naturalOrder());
+//        if (stationTime.isPresent()) {
+//            return DISPLAY_DATE_FORMAT.format(stationTime.get());
+//        }
+//        if (lastSuccessfulRefresh != null) {
+//            return DISPLAY_DATE_FORMAT.format(lastSuccessfulRefresh);
+//        }
+//        return "Unavailable";
+//    }
 
     public synchronized String getStatusMessage() {
         if (usingLiveFallback) {

--- a/src/main/java/com/laughingalpaca/bikeviewapp/FirestoreSeeder.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/FirestoreSeeder.java
@@ -1,0 +1,32 @@
+package com.laughingalpaca.bikeviewapp;
+
+import com.google.cloud.firestore.Firestore;
+
+public final class FirestoreSeeder {
+    private static final String USAGE = """
+            Usage:
+            mvn -q -DskipTests exec:java -Dexec.mainClass=com.laughingalpaca.bikeviewapp.FirestoreSeeder -Dexec.args="live"
+            """;
+
+    private FirestoreSeeder() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0 || !"live".equalsIgnoreCase(args[0])) {
+            System.out.println(USAGE);
+            return;
+        }
+
+        DataHandler dataHandler = DataHandler.getInstance();
+        Firestore firestore = dataHandler.getFirestore();
+
+        if (firestore == null) {
+            throw new IllegalStateException("Firestore connection is unavailable. Check config/firebase-service-account.json");
+        }
+
+        GbfsSyncService gbfsSyncService = new GbfsSyncService();
+        int stationCount = gbfsSyncService.syncLiveStationsToFirestore(firestore);
+
+        System.out.println("Synced " + stationCount + " live stations into Firestore.");
+    }
+}

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
@@ -3,6 +3,11 @@ package com.laughingalpaca.bikeviewapp;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gluonhq.maps.MapPoint;
 import java.net.http.HttpClient;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public final class GbfsSyncService {
 
@@ -17,5 +22,19 @@ public final class GbfsSyncService {
         this.httpClient = HttpClient.newHttpClient();
         this.objectMapper = new ObjectMapper();
         this.geoBoundaryService = new GeoBoundaryService();
+    }
+
+    private JsonNode fetchJson(String url) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .GET()
+                .header("Accept", "application/json")
+                .header("User-Agent", "BikeViewApp/1.0")
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("GBFS request failed with status " + response.statusCode() + " for " + url);
+        }
+        return objectMapper.readTree(response.body());
     }
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
@@ -2,22 +2,27 @@ package com.laughingalpaca.bikeviewapp;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gluonhq.maps.MapPoint;
+
 import java.net.http.HttpClient;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.laughingalpaca.bikeviewapp.Model.Station;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.WriteResult;
+
 import java.util.concurrent.ExecutionException;
 
 
@@ -88,6 +93,7 @@ public final class GbfsSyncService {
         geoBoundaryService.enrichStationsWithBoroughs(stations);
         return stations;
     }
+
     public int syncLiveStationsToFirestore(Firestore firestore) throws IOException, InterruptedException, ExecutionException {
         List<Station> stations = fetchLiveStations();
 

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
@@ -8,6 +8,13 @@ import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.laughingalpaca.bikeviewapp.Model.Station;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public final class GbfsSyncService {
 
@@ -37,4 +44,44 @@ public final class GbfsSyncService {
         }
         return objectMapper.readTree(response.body());
     }
+
+    public List<Station> fetchLiveStations() throws IOException, InterruptedException {
+        JsonNode stationInformationRoot = fetchJson(STATION_INFORMATION_URL);
+        JsonNode stationStatusRoot = fetchJson(STATION_STATUS_URL);
+
+        Map<String, JsonNode> statusByStationId = new HashMap<>();
+        Iterator<JsonNode> stationStatusIterator = stationStatusRoot.path("data").path("stations").elements();
+        while (stationStatusIterator.hasNext()) {
+            JsonNode stationStatus = stationStatusIterator.next();
+            String stationId = stationStatus.path("station_id").asText("");
+            if (!stationId.isBlank()) {
+                statusByStationId.put(stationId, stationStatus);
+            }
+        }
+
+        Instant feedUpdatedAt = Instant.ofEpochSecond(stationStatusRoot.path("last_updated").asLong(Instant.now().getEpochSecond()));
+
+        List<Station> stations = new ArrayList<>();
+        Iterator<JsonNode> stationInformationIterator = stationInformationRoot.path("data").path("stations").elements();
+        while (stationInformationIterator.hasNext()) {
+            JsonNode stationInformation = stationInformationIterator.next();
+            String stationId = stationInformation.path("station_id").asText("");
+            String stationName = stationInformation.path("name").asText("");
+            double latitude = stationInformation.path("lat").asDouble(Double.NaN);
+            double longitude = stationInformation.path("lon").asDouble(Double.NaN);
+
+            if (stationId.isBlank() || stationName.isBlank() || Double.isNaN(latitude) || Double.isNaN(longitude)) {
+                continue;
+            }
+
+            JsonNode statusNode = statusByStationId.get(stationId);
+            int bikeCount = statusNode == null ? 0 : statusNode.path("num_bikes_available").asInt(0);
+
+            stations.add(new Station(stationId, stationName, new MapPoint(latitude, longitude), bikeCount, "", "", feedUpdatedAt));
+        }
+
+        geoBoundaryService.enrichStationsWithBoroughs(stations);
+        return stations;
+    }
+
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
@@ -1,0 +1,21 @@
+package com.laughingalpaca.bikeviewapp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gluonhq.maps.MapPoint;
+import java.net.http.HttpClient;
+
+public final class GbfsSyncService {
+
+    public static final String STATION_INFORMATION_URL = "https://gbfs.lyft.com/gbfs/1.1/bkn/en/station_information.json";
+    public static final String STATION_STATUS_URL = "https://gbfs.lyft.com/gbfs/1.1/bkn/en/station_status.json";
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final GeoBoundaryService geoBoundaryService;
+
+    public GbfsSyncService() {
+        this.httpClient = HttpClient.newHttpClient();
+        this.objectMapper = new ObjectMapper();
+        this.geoBoundaryService = new GeoBoundaryService();
+    }
+}

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
@@ -15,6 +15,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.WriteResult;
+import java.util.concurrent.ExecutionException;
+
 
 public final class GbfsSyncService {
 
@@ -83,5 +88,32 @@ public final class GbfsSyncService {
         geoBoundaryService.enrichStationsWithBoroughs(stations);
         return stations;
     }
+    public int syncLiveStationsToFirestore(Firestore firestore) throws IOException, InterruptedException, ExecutionException {
+        List<Station> stations = fetchLiveStations();
 
+        for (Station station : stations) {
+            Map<String, Object> stationDocument = new HashMap<>();
+            stationDocument.put("stationId", station.getStation_id());
+            stationDocument.put("stationName", station.getStation_name());
+            stationDocument.put("latitude", station.getLocation().getLatitude());
+            stationDocument.put("longitude", station.getLocation().getLongitude());
+            stationDocument.put("estimatedBikeCount", station.getEstimated_bike_count());
+            stationDocument.put("borough", station.getBorough());
+            stationDocument.put("zipCode", station.getZip_code());
+            stationDocument.put("lastUpdated", station.getLast_updated() == null ? Instant.now().toString() : station.getLast_updated().toString());
+
+            ApiFuture<WriteResult> future = firestore.collection("stations")
+                    .document(station.getStation_id())
+                    .set(stationDocument);
+            future.get();
+        }
+
+        Map<String, Object> metadataDocument = new HashMap<>();
+        metadataDocument.put("lastUpdated", Instant.now().toString());
+        metadataDocument.put("sourceName", "Lyft GBFS station feed");
+        metadataDocument.put("syncStatus", "live_sync_complete");
+        firestore.collection("app_metadata").document("status").set(metadataDocument).get();
+
+        return stations.size();
+    }
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundary.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundary.java
@@ -12,4 +12,18 @@ public record GeoBoundary(
         double minLongitude,
         double maxLongitude
 ) {
+    public MapPoint getCenter() {
+        return new MapPoint(
+                (minLatitude + maxLatitude) / 2.0,
+                (minLongitude + maxLongitude) / 2.0
+        );
+    }
+
+    public double getLatitudeSpan() {
+        return Math.max(0.0, maxLatitude - minLatitude);
+    }
+
+    public double getLongitudeSpan() {
+        return Math.max(0.0, maxLongitude - minLongitude);
+    }
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundary.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundary.java
@@ -1,0 +1,15 @@
+package com.laughingalpaca.bikeviewapp;
+
+import com.gluonhq.maps.MapPoint;
+import java.util.List;
+
+public record GeoBoundary(
+        String id,
+        String label,
+        List<List<MapPoint>> rings,
+        double minLatitude,
+        double maxLatitude,
+        double minLongitude,
+        double maxLongitude
+) {
+}

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundary.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundary.java
@@ -12,6 +12,14 @@ public record GeoBoundary(
         double minLongitude,
         double maxLongitude
 ) {
+    public boolean contains(MapPoint point) {
+        boolean inside = false;
+        for (List<MapPoint> ring : rings) {
+            inside ^= isInsideRing(point, ring);
+        }
+        return inside;
+    }
+
     public MapPoint getCenter() {
         return new MapPoint(
                 (minLatitude + maxLatitude) / 2.0,
@@ -25,5 +33,31 @@ public record GeoBoundary(
 
     public double getLongitudeSpan() {
         return Math.max(0.0, maxLongitude - minLongitude);
+    }
+
+    private boolean isInsideRing(MapPoint point, List<MapPoint> ring) {
+        boolean inside = false;
+        double x = point.getLongitude();
+        double y = point.getLatitude();
+
+        for (int i = 0, j = ring.size() - 1; i < ring.size(); j = i++) {
+            MapPoint current = ring.get(i);
+            MapPoint previous = ring.get(j);
+
+            double xi = current.getLongitude();
+            double yi = current.getLatitude();
+            double xj = previous.getLongitude();
+            double yj = previous.getLatitude();
+
+            boolean intersects = ((yi > y) != (yj > y))
+                    && (x < (xj - xi) * (y - yi)
+                    / ((yj - yi) == 0 ? Double.MIN_NORMAL : (yj - yi)) + xi);
+
+            if (intersects) {
+                inside = !inside;
+            }
+        }
+
+        return inside;
     }
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundaryService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundaryService.java
@@ -1,4 +1,5 @@
 package com.laughingalpaca.bikeviewapp;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gluonhq.maps.MapPoint;
@@ -30,6 +31,7 @@ public class GeoBoundaryService {
     private final ObjectMapper objectMapper;
     private List<GeoBoundary> boroughBoundaries;
     private final Map<String, Optional<GeoBoundary>> zipBoundaryCache = new HashMap<>();
+
     public GeoBoundaryService() {
         httpClient = HttpClient.newHttpClient();
         objectMapper = new ObjectMapper();
@@ -43,8 +45,7 @@ public class GeoBoundaryService {
                 String borough = resolveBorough(station.getLocation());
                 station.setBorough(borough);
             }
-        }
-        catch (IOException | InterruptedException exception) {
+        } catch (IOException | InterruptedException exception) {
             warnings.add("Unable to load borough boundaries.");
         }
         return warnings;
@@ -66,8 +67,7 @@ public class GeoBoundaryService {
             Optional<GeoBoundary> boundary = boundaries.stream().findFirst();
             zipBoundaryCache.put(normalizedZip, boundary);
             return boundary;
-        }
-        catch (IOException | InterruptedException exception) {
+        } catch (IOException | InterruptedException exception) {
             zipBoundaryCache.put(normalizedZip, Optional.empty());
             return Optional.empty();
         }
@@ -79,8 +79,7 @@ public class GeoBoundaryService {
         }
         try {
             ensureBoroughBoundariesLoaded();
-        }
-        catch (IOException | InterruptedException exception) {
+        } catch (IOException | InterruptedException exception) {
             if (exception instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundaryService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundaryService.java
@@ -1,0 +1,200 @@
+package com.laughingalpaca.bikeviewapp;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gluonhq.maps.MapPoint;
+import com.laughingalpaca.bikeviewapp.Model.Station;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public class GeoBoundaryService {
+    private static final String BOROUGH_BOUNDARIES_URL =
+            "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/9/query"
+                    + "?where=STATE%20%3D%20'36'%20AND%20COUNTY%20IN%20('005','047','061','081','085')"
+                    + "&outFields=NAME,COUNTY&returnGeometry=true&f=geojson";
+    private static final String ZIP_BOUNDARY_URL_TEMPLATE =
+            "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer/2/query"
+                    + "?where=%s&outFields=ZCTA5&returnGeometry=true&f=geojson";
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private List<GeoBoundary> boroughBoundaries;
+    private final Map<String, Optional<GeoBoundary>> zipBoundaryCache = new HashMap<>();
+    public GeoBoundaryService() {
+        httpClient = HttpClient.newHttpClient();
+        objectMapper = new ObjectMapper();
+    }
+
+    public synchronized List<String> enrichStationsWithBoroughs(List<Station> stations) {
+        List<String> warnings = new ArrayList<>();
+        try {
+            ensureBoroughBoundariesLoaded();
+            for (Station station : stations) {
+                String borough = resolveBorough(station.getLocation());
+                station.setBorough(borough);
+            }
+        }
+        catch (IOException | InterruptedException exception) {
+            warnings.add("Unable to load borough boundaries.");
+        }
+        return warnings;
+    }
+
+    public synchronized Optional<GeoBoundary> getZipBoundary(String zipCode) {
+        if (zipCode == null || zipCode.isBlank()) {
+            return Optional.empty();
+        }
+        String normalizedZip = zipCode.trim();
+        if (zipBoundaryCache.containsKey(normalizedZip)) {
+            return zipBoundaryCache.get(normalizedZip);
+        }
+        try {
+            String whereClause = URLEncoder.encode("ZCTA5 = '" + normalizedZip + "'", StandardCharsets.UTF_8);
+            String url = ZIP_BOUNDARY_URL_TEMPLATE.formatted(whereClause);
+            JsonNode root = fetchJson(url);
+            List<GeoBoundary> boundaries = parseFeatureCollection(root, "ZCTA5", false);
+            Optional<GeoBoundary> boundary = boundaries.stream().findFirst();
+            zipBoundaryCache.put(normalizedZip, boundary);
+            return boundary;
+        }
+        catch (IOException | InterruptedException exception) {
+            zipBoundaryCache.put(normalizedZip, Optional.empty());
+            return Optional.empty();
+        }
+    }
+
+    public String resolveBorough(MapPoint point) {
+        if (point == null) {
+            return "";
+        }
+        try {
+            ensureBoroughBoundariesLoaded();
+        }
+        catch (IOException | InterruptedException exception) {
+            if (exception instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return "";
+        }
+        for (GeoBoundary boundary : boroughBoundaries) {
+            if (boundary.contains(point)) {
+                return boundary.label();
+            }
+        }
+        return "";
+    }
+
+    public boolean isStationInsideZip(Station station, GeoBoundary zipBoundary) {
+        return station != null
+                && station.getLocation() != null
+                && zipBoundary != null
+                && zipBoundary.contains(station.getLocation());
+    }
+
+    private void ensureBoroughBoundariesLoaded() throws IOException, InterruptedException {
+        if (boroughBoundaries != null) {
+            return;
+        }
+        JsonNode root = fetchJson(BOROUGH_BOUNDARIES_URL);
+        boroughBoundaries = parseFeatureCollection(root, "COUNTY", true);
+    }
+
+    private JsonNode fetchJson(String url) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .GET()
+                .header("Accept", "application/json")
+                .header("User-Agent", "BikeViewApp/1.0")
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("Boundary request failed with status " + response.statusCode());
+        }
+        return objectMapper.readTree(response.body());
+    }
+
+    private List<GeoBoundary> parseFeatureCollection(JsonNode root, String propertyName, boolean mapCountyToBorough) {
+        List<GeoBoundary> boundaries = new ArrayList<>();
+        for (JsonNode feature : root.path("features")) {
+            JsonNode properties = feature.path("properties");
+            String id = properties.path(propertyName).asText("");
+            if (id.isBlank()) {
+                continue;
+            }
+            String label = id;
+            if (mapCountyToBorough) {
+                label = mapCountyToBorough(properties.path("NAME").asText(""), id);
+            }
+            JsonNode geometry = feature.path("geometry");
+            List<List<MapPoint>> rings = parseGeometryRings(geometry);
+            if (rings.isEmpty()) {
+                continue;
+            }
+            double minLatitude = Double.POSITIVE_INFINITY;
+            double maxLatitude = Double.NEGATIVE_INFINITY;
+            double minLongitude = Double.POSITIVE_INFINITY;
+            double maxLongitude = Double.NEGATIVE_INFINITY;
+            for (List<MapPoint> ring : rings) {
+                for (MapPoint point : ring) {
+                    minLatitude = Math.min(minLatitude, point.getLatitude());
+                    maxLatitude = Math.max(maxLatitude, point.getLatitude());
+                    minLongitude = Math.min(minLongitude, point.getLongitude());
+                    maxLongitude = Math.max(maxLongitude, point.getLongitude());
+                }
+            }
+            boundaries.add(new GeoBoundary(id, label, rings, minLatitude, maxLatitude, minLongitude, maxLongitude));
+        }
+        return boundaries;
+    }
+
+    private List<List<MapPoint>> parseGeometryRings(JsonNode geometry) {
+        List<List<MapPoint>> rings = new ArrayList<>();
+        String type = geometry.path("type").asText("");
+        JsonNode coordinates = geometry.path("coordinates");
+        if ("Polygon".equalsIgnoreCase(type)) {
+            addPolygonRings(rings, coordinates);
+        } else if ("MultiPolygon".equalsIgnoreCase(type)) {
+            for (JsonNode polygonNode : coordinates) {
+                addPolygonRings(rings, polygonNode);
+            }
+        }
+        return rings;
+    }
+
+    private void addPolygonRings(List<List<MapPoint>> rings, JsonNode polygonCoordinates) {
+        for (JsonNode ringNode : polygonCoordinates) {
+            List<MapPoint> ring = new ArrayList<>();
+            for (JsonNode coordinateNode : ringNode) {
+                if (coordinateNode.size() < 2) {
+                    continue;
+                }
+                double longitude = coordinateNode.get(0).asDouble();
+                double latitude = coordinateNode.get(1).asDouble();
+                ring.add(new MapPoint(latitude, longitude));
+            }
+            if (ring.size() >= 3) {
+                rings.add(ring);
+            }
+        }
+    }
+
+    private String mapCountyToBorough(String countyName, String countyCode) {
+        return switch (countyCode) {
+            case "005" -> "Bronx";
+            case "047" -> "Brooklyn";
+            case "061" -> "Manhattan";
+            case "081" -> "Queens";
+            case "085" -> "Staten Island";
+            default -> countyName == null ? "" : countyName.trim();
+        };
+    }
+}

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundaryService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundaryService.java
@@ -15,7 +15,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 

--- a/src/main/java/com/laughingalpaca/bikeviewapp/Model/Ride.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/Model/Ride.java
@@ -13,4 +13,11 @@ public class Ride {
 
     public Ride(String rideId, RideableType rideableType, Station startStation, Station endStation, Instant startedAt, Instant endedAt) {
     }
+
+    public Station getStart_station() {
+    }
+
+    public Station getEnd_station() {
+        return null;
+    }
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/Model/Ride.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/Model/Ride.java
@@ -1,5 +1,7 @@
 package com.laughingalpaca.bikeviewapp.Model;
 
+import java.time.Instant;
+
 //TODO: Finish this class so we can do get/set for the variables below
 // Should also have methods for getting the ride length(the Citi bike data includes a start and end time, use this data to come up with te ride_length)
 public class Ride {
@@ -8,4 +10,7 @@ public class Ride {
     Station start_station;
     Station end_station;
     float ride_length;
+
+    public Ride(String rideId, RideableType rideableType, Station startStation, Station endStation, Instant startedAt, Instant endedAt) {
+    }
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/Model/Ride.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/Model/Ride.java
@@ -14,7 +14,9 @@ public class Ride {
     public Ride(String rideId, RideableType rideableType, Station startStation, Station endStation, Instant startedAt, Instant endedAt) {
     }
 
+    //TODO: RETURN TO THIS
     public Station getStart_station() {
+        return null;
     }
 
     public Station getEnd_station() {

--- a/src/main/java/com/laughingalpaca/bikeviewapp/Model/Station.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/Model/Station.java
@@ -52,7 +52,22 @@ public class Station {
         this.estimated_bike_count = estimated_bike_count;
     }
 
+    //TODO: RETURN TO THIS
     public Object getLast_updated() {
         return null;
+    }
+
+    //TODO: RETURN TO THIS
+    public String getBorough() {
+        return null;
+    }
+
+    //TODO: RETURN TO THIS
+    public Object getZip_code() {
+        return null;
+    }
+
+    //TODO: RETURN TO THIS
+    public void setBorough(String borough) {
     }
 }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/Model/Station.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/Model/Station.java
@@ -2,7 +2,12 @@ package com.laughingalpaca.bikeviewapp.Model;
 
 import com.gluonhq.maps.MapPoint;
 
+import java.time.Instant;
+
 public class Station {
+    public Station(String stationId, String stationName, MapPoint location, int estimatedBikeCount, String borough, String s, Instant lastUpdated) {
+    }
+
     public String getStation_id() {
         return station_id;
     }
@@ -45,5 +50,9 @@ public class Station {
         this.station_name = station_name;
         this.location = location;
         this.estimated_bike_count = estimated_bike_count;
+    }
+
+    public Object getLast_updated() {
+        return null;
     }
 }


### PR DESCRIPTION
Adds live-only Firestore seeder command. The new seeder connects through DataHandler, writes the latest GBFS station data into Firestore, and prints the synced station count.
