### PR TITLE
Security hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ build/
 
 ### Local secrets ###
 config/*.json
+config/**/*.json
 /src/main/resources/com/laughingalpaca/bikeviewapp/firebase_info/
 /src/main/resources/com/laughingalpaca/bikeviewapp/firebase_info/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 Information about our project here...
 
+## Demo Security Notes
+
+This project can use a local Firebase Admin service-account JSON for class/demo runs. Keep those files under `config/` and never commit them. A production desktop release should move Firebase access behind a backend API, or use Firebase client authentication with Firestore security rules.
+
+For demo credentials, use least-privilege access limited to the app's station sync data. The intended write path is `FirestoreSeeder`, which writes `stations/{stationId}` and `app_metadata/status` from the live GBFS station feed.
+
 Launch<br>
 <img width="377" height="587" alt="Launch" src="https://github.com/user-attachments/assets/817c7d36-7068-4fb5-bc2d-e7c53a80c3d4" />
 

--- a/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
@@ -32,6 +32,11 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 public class DataHandler {
+    private static final String FIRESTORE_UNAVAILABLE_MESSAGE =
+            "Firestore unavailable. Using live Citi Bike feed when possible.";
+    private static final String FIRESTORE_CONNECTED_MESSAGE = "Connected to Firestore.";
+    private static final String LIVE_FEED_UNAVAILABLE_MESSAGE = "Live Citi Bike feed unavailable.";
+    private static final String RIDE_DATA_UNAVAILABLE_MESSAGE = "Ride data unavailable.";
     private static final List<Path> SERVICE_ACCOUNT_PATHS = List.of(
             Path.of("config", "firebase-service-account.json"),
             Path.of("config", "firebase_info", "bikeviewappKey.json"),
@@ -44,7 +49,8 @@ public class DataHandler {
     private final GeoBoundaryService geoBoundaryService = new GeoBoundaryService();
     private Firestore firestore;
     private String projectId = "Unavailable";
-    private String lastError = "Not connected";
+    private String lastError = FIRESTORE_UNAVAILABLE_MESSAGE;
+    private String lastDiagnosticError = "";
     private Instant lastSuccessfulRefresh;
     private boolean usingLiveFallback;
 
@@ -64,14 +70,16 @@ public class DataHandler {
         try {
             firestore.collection("app_metadata").document("status").get().get();
             lastError = "";
+            lastDiagnosticError = "";
             lastSuccessfulRefresh = Instant.now();
             return true;
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             lastError = "Firestore connection check interrupted.";
+            lastDiagnosticError = "Firestore connection check interrupted.";
             return false;
         } catch (ExecutionException | RuntimeException exception) {
-            lastError = buildReadableError("Firestore connection failed.", exception);
+            recordFailure(FIRESTORE_UNAVAILABLE_MESSAGE, "Firestore connection failed.", exception);
             return false;
         }
     }
@@ -99,8 +107,9 @@ public class DataHandler {
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             lastError = "Station load interrupted.";
+            lastDiagnosticError = "Station load interrupted.";
         } catch (ExecutionException | RuntimeException exception) {
-            lastError = buildReadableError("Unable to load stations from Firestore.", exception);
+            recordFailure(FIRESTORE_UNAVAILABLE_MESSAGE, "Unable to load stations from Firestore.", exception);
         }
         return loadStationsFromFallback();
     }
@@ -151,8 +160,9 @@ public class DataHandler {
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             lastError = "Ride lookup interrupted.";
+            lastDiagnosticError = "Ride lookup interrupted.";
         } catch (ExecutionException | RuntimeException exception) {
-            lastError = buildReadableError("Unable to load rides from Firestore.", exception);
+            recordFailure(RIDE_DATA_UNAVAILABLE_MESSAGE, "Unable to load rides from Firestore.", exception);
         }
         return List.of();
     }
@@ -198,9 +208,9 @@ public class DataHandler {
             return "Using live Citi Bike feed because Firestore is unavailable.";
         }
         if (firestore != null && (lastError == null || lastError.isBlank())) {
-            return "Connected to Firestore.";
+            return FIRESTORE_CONNECTED_MESSAGE;
         }
-        return lastError == null || lastError.isBlank() ? "Firestore connection unavailable." : lastError;
+        return lastError == null || lastError.isBlank() ? "Firestore unavailable." : lastError;
     }
 
     public synchronized Firestore getFirestore() {
@@ -221,7 +231,8 @@ public class DataHandler {
     private Firestore initializeFirestore() {
         Path serviceAccountPath = resolveServiceAccountPath();
         if (serviceAccountPath == null) {
-            lastError = "Missing Firebase key. Checked: " + SERVICE_ACCOUNT_PATHS;
+            lastError = FIRESTORE_UNAVAILABLE_MESSAGE;
+            lastDiagnosticError = "Firebase service-account key is not configured for this local demo.";
             return null;
         }
         try (FileInputStream inputStream = new FileInputStream(serviceAccountPath.toFile())) {
@@ -241,7 +252,7 @@ public class DataHandler {
             }
             return FirestoreClient.getFirestore(firebaseApp);
         } catch (IOException | RuntimeException exception) {
-            lastError = buildReadableError("Unable to initialize Firebase.", exception);
+            recordFailure(FIRESTORE_UNAVAILABLE_MESSAGE, "Unable to initialize Firebase.", exception);
             return null;
         }
     }
@@ -401,6 +412,7 @@ public class DataHandler {
             if (exception instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
+            recordFailure(LIVE_FEED_UNAVAILABLE_MESSAGE, "Unable to load stations from live GBFS feed.", exception);
             return new ArrayList<>(cachedStations);
         }
     }
@@ -423,6 +435,11 @@ public class DataHandler {
             return prefix;
         }
         return prefix + " " + message;
+    }
+
+    private void recordFailure(String userMessage, String diagnosticPrefix, Exception exception) {
+        lastError = userMessage;
+        lastDiagnosticError = buildReadableError(diagnosticPrefix, exception);
     }
 }
 

--- a/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/DataHandler.java
@@ -32,7 +32,11 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 public class DataHandler {
-    private static final Path SERVICE_ACCOUNT_PATH = Path.of("config", ".../BikeViewApp/src/main/resources/firebase_info/bikeviewappKey.json");
+    private static final List<Path> SERVICE_ACCOUNT_PATHS = List.of(
+            Path.of("config", "firebase-service-account.json"),
+            Path.of("config", "firebase_info", "bikeviewappKey.json"),
+            Path.of("config", "csc325--citibikeapp-firebase-adminsdk-fbsvc-af39f79319.json")
+    );
     private static final DateTimeFormatter DISPLAY_DATE_FORMAT = DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a").withZone(ZoneId.systemDefault());
     private static final DataHandler INSTANCE = new DataHandler();
     private final List<Station> cachedStations = new ArrayList<>();
@@ -215,11 +219,12 @@ public class DataHandler {
     }
 
     private Firestore initializeFirestore() {
-        if (!Files.exists(SERVICE_ACCOUNT_PATH)) {
-            lastError = "Missing Firebase key at " + SERVICE_ACCOUNT_PATH;
+        Path serviceAccountPath = resolveServiceAccountPath();
+        if (serviceAccountPath == null) {
+            lastError = "Missing Firebase key. Checked: " + SERVICE_ACCOUNT_PATHS;
             return null;
         }
-        try (FileInputStream inputStream = new FileInputStream(SERVICE_ACCOUNT_PATH.toFile())) {
+        try (FileInputStream inputStream = new FileInputStream(serviceAccountPath.toFile())) {
             ServiceAccountCredentials credentials = ServiceAccountCredentials.fromStream(inputStream);
             projectId = credentials.getProjectId() == null || credentials.getProjectId().isBlank()
                     ? projectId
@@ -239,6 +244,13 @@ public class DataHandler {
             lastError = buildReadableError("Unable to initialize Firebase.", exception);
             return null;
         }
+    }
+
+    private Path resolveServiceAccountPath() {
+        return SERVICE_ACCOUNT_PATHS.stream()
+                .filter(Files::exists)
+                .findFirst()
+                .orElse(null);
     }
 
     private Optional<Instant> getMetadataLastUpdated() {

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GbfsSyncService.java
@@ -12,6 +12,7 @@ import java.net.http.HttpResponse;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.laughingalpaca.bikeviewapp.Model.Station;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,27 +31,35 @@ public final class GbfsSyncService {
 
     public static final String STATION_INFORMATION_URL = "https://gbfs.lyft.com/gbfs/1.1/bkn/en/station_information.json";
     public static final String STATION_STATUS_URL = "https://gbfs.lyft.com/gbfs/1.1/bkn/en/station_status.json";
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final int MAX_JSON_RESPONSE_BYTES = 10 * 1024 * 1024;
 
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
     private final GeoBoundaryService geoBoundaryService;
 
     public GbfsSyncService() {
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(REQUEST_TIMEOUT)
+                .build();
         this.objectMapper = new ObjectMapper();
         this.geoBoundaryService = new GeoBoundaryService();
     }
 
     private JsonNode fetchJson(String url) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(REQUEST_TIMEOUT)
                 .GET()
                 .header("Accept", "application/json")
                 .header("User-Agent", "BikeViewApp/1.0")
                 .build();
 
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             throw new IOException("GBFS request failed with status " + response.statusCode() + " for " + url);
+        }
+        if (response.body().length > MAX_JSON_RESPONSE_BYTES) {
+            throw new IOException("GBFS response exceeded the allowed size.");
         }
         return objectMapper.readTree(response.body());
     }

--- a/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundaryService.java
+++ b/src/main/java/com/laughingalpaca/bikeviewapp/GeoBoundaryService.java
@@ -12,13 +12,18 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 public class GeoBoundaryService {
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final int MAX_JSON_RESPONSE_BYTES = 10 * 1024 * 1024;
+    private static final Pattern ZIP_CODE_PATTERN = Pattern.compile("\\d{5}");
     private static final String BOROUGH_BOUNDARIES_URL =
             "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/9/query"
                     + "?where=STATE%20%3D%20'36'%20AND%20COUNTY%20IN%20('005','047','061','081','085')"
@@ -32,7 +37,9 @@ public class GeoBoundaryService {
     private final Map<String, Optional<GeoBoundary>> zipBoundaryCache = new HashMap<>();
 
     public GeoBoundaryService() {
-        httpClient = HttpClient.newHttpClient();
+        httpClient = HttpClient.newBuilder()
+                .connectTimeout(REQUEST_TIMEOUT)
+                .build();
         objectMapper = new ObjectMapper();
     }
 
@@ -55,6 +62,9 @@ public class GeoBoundaryService {
             return Optional.empty();
         }
         String normalizedZip = zipCode.trim();
+        if (!ZIP_CODE_PATTERN.matcher(normalizedZip).matches()) {
+            return Optional.empty();
+        }
         if (zipBoundaryCache.containsKey(normalizedZip)) {
             return zipBoundaryCache.get(normalizedZip);
         }
@@ -109,13 +119,17 @@ public class GeoBoundaryService {
 
     private JsonNode fetchJson(String url) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(REQUEST_TIMEOUT)
                 .GET()
                 .header("Accept", "application/json")
                 .header("User-Agent", "BikeViewApp/1.0")
                 .build();
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             throw new IOException("Boundary request failed with status " + response.statusCode());
+        }
+        if (response.body().length > MAX_JSON_RESPONSE_BYTES) {
+            throw new IOException("Boundary response exceeded the allowed size.");
         }
         return objectMapper.readTree(response.body());
     }


### PR DESCRIPTION
Security hardening branch is ready for review.

This branch adds demo-safe security improvements without changing the main app flow. The app still supports the local Firebase Admin key for our class/demo setup, but the branch reduces the risk of accidentally exposing secrets or backend details.

What changed:
- Added stronger `.gitignore` protection for nested local Firebase/config JSON files.
- Replaced detailed backend/Firebase exception text in the UI with safer user-facing status messages.
- Added request timeouts for GBFS and Census API calls so the app does not hang indefinitely.
- Added response-size limits before parsing external JSON.
- Added strict 5-digit ZIP validation before calling the Census boundary API.
- Added README notes explaining that Firebase Admin credentials are local/demo-only and should be least-privilege.

Verification:
- Clean compile passed with `mvn -q clean -DskipTests compile`.
- Secret ignore rules were verified for both direct and nested config paths.

Note:
This branch is demo hardening, not a full production backend migration. For a production desktop release, Firebase access should move behind a backend API or use Firebase client auth with Firestore security rules.